### PR TITLE
feat: accept module options

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -2,8 +2,8 @@ import { resolve } from 'path'
 
 import pkg from '../package.json'
 
-export default function nuxtWebfontloader() {
-  const { webfontloader: options } = this.options
+export default function nuxtWebfontloader(moduleOptions) {
+  const options = { ...this.options.webfontloader, ...moduleOptions }
 
   if (!options || !Object.keys(options).length) {
     return


### PR DESCRIPTION
Accept module options to be able to also setup the module as the following example :

```js
export default {
  modules: [
    ['nuxt-webfontloader', {
      google: {
        families: ['Roboto:400']
      }
    }]
  ]
}
```